### PR TITLE
Release v1.1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 - Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
 - Added `l10n_it.xml` by [FirenzeIT](https://github.com/FirenzeIT)
+- Added `l10n_ru.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
+- Added `l10n_uk.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
 - Fixed additional costs for selling owned vehicles for [#10](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/10)
 
 ## [v1.0.0.0] - 2024-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 - Update moddesc version
 - Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
-- Added translation for TR by [RuyaSavascisi](https://github.com/RuyaSavascisi)
+- Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
+- Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
 
 ## [v1.0.0.0] - 2024-11-20
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 - Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
+- Added `l10n_it.xml` by [FirenzeIT](https://github.com/FirenzeIT)
 
 ## [v1.0.0.0] - 2024-11-20
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+- Update moddesc version
+- Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
 - Added translation for TR by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 
 ## [v1.0.0.0] - 2024-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 - Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
 - Added `l10n_it.xml` by [FirenzeIT](https://github.com/FirenzeIT)
+- Fixed additional costs for selling owned vehicles for [#10](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/10)
 
 ## [v1.0.0.0] - 2024-11-20
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+- Added translation for TR by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 
 ## [v1.0.0.0] - 2024-11-20
 - Ported from LS22 to LS25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+
+
+## [v1.1.0.0] - {waiting-for-modhub}
 - Update moddesc version
 - Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
+- Added `l10n_ru.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
+- Added `l10n_uk.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
 
-
-## [v1.1.0.0] - {waiting-for-modhub}
+## [v1.1.0.0] - 2025-01-28
 - Update moddesc version
 - Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
 - Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
 - Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
 - Added `l10n_it.xml` by [FirenzeIT](https://github.com/FirenzeIT)
-- Added `l10n_ru.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
-- Added `l10n_uk.xml` by [Gonimy-Vetrom](https://github.com/Gonimy-Vetrom)
 - Fixed additional costs for selling owned vehicles for [#10](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/10)
 
 ## [v1.0.0.0] - 2024-11-20

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -5,6 +5,7 @@
   <title>
     <en>Extended Leasing</en>
     <de>Erweitertes Leasing</de>
+	<tr>Genişletilmiş Kiralama</tr>
   </title>
   <description>
     <en><![CDATA[Stop with breaking down the dealer's tractors and equipment and not having to pay for it.
@@ -31,10 +32,12 @@ Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https
     <text name="base_costs">
       <en>Base Costs Return</en>
       <de>Kaution zurück</de>
+	  <tr>Temel Masrafların İadesi</tr>
     </text>
     <text name="washing_costs">
       <en>Washing Costs</en>
       <de>Reinigungsgebühr</de>
+	  <tr>Yıkama Masrafı</tr>
     </text>
   </l10n>
 </modDesc>

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -7,6 +7,7 @@
     <de>Erweitertes Leasing</de>
 	  <tr>Genişletilmiş Kiralama</tr>
     <br>Locação estendido</br>
+    <it>Noleggio Esteso</it>
   </title>
   <description>
     <en><![CDATA[Stop with breaking down the dealer's tractors and equipment and not having to pay for it.
@@ -37,6 +38,13 @@ Para isso, você recebe de volta os custos base (depósito) que foram pagos no i
 
 Para mais informações, ajuda e relatórios de problemas, visite o <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></br>
+    <it><![CDATA[Stop con il rompere i trattori e le attrezzature del rivenditore senza dover pagare per i danni.
+Con questa mod devi pagare i costi di riparazione quando restituisci il trattore o l'attrezzatura. Inoltre, devi pagare i costi di lavaggio, massimo il 30% dei costi base (deposito), per un trattore o un'attrezzatura sporchi.
+
+Per questo ti viene restituito il deposito che è stato pagato all'inizio.
+
+Per maggiori informazioni, assistenza e segnalazione di problemi, visita <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
+]]></it>
   </description>
   <iconFilename>icon_ExtendedLeasing.dds</iconFilename>
   <multiplayer supported="true" />

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -5,8 +5,8 @@
   <title>
     <en>Extended Leasing</en>
     <de>Erweitertes Leasing</de>
-	  <tr>Genişletilmiş Kiralama</tr>
-    <br>Locação estendido</br>
+    <tr>Genişletilmiş Kiralama</tr>
+    <br>Locação Estendido</br>
     <it>Noleggio Esteso</it>
   </title>
   <description>

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<modDesc descVersion="92">
+<modDesc descVersion="94">
   <author>Peppie84</author>
   <version>1.0.0.0</version>
   <title>
@@ -28,16 +28,5 @@ Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https
   <extraSourceFiles>
     <sourceFile filename="src/main.lua" />
   </extraSourceFiles>
-  <l10n>
-    <text name="base_costs">
-      <en>Base Costs Return</en>
-      <de>Kaution zurück</de>
-	  <tr>Temel Masrafların İadesi</tr>
-    </text>
-    <text name="washing_costs">
-      <en>Washing Costs</en>
-      <de>Reinigungsgebühr</de>
-	  <tr>Yıkama Masrafı</tr>
-    </text>
-  </l10n>
+  <l10n filenamePrefix="translations/l10n" />
 </modDesc>

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="94">
   <author>Peppie84</author>
-  <version>1.0.0.0</version>
+  <version>1.1.0.0</version>
   <title>
     <en>Extended Leasing</en>
     <de>Erweitertes Leasing</de>
@@ -15,12 +15,22 @@ With this mod you have to pay the repair costs when you return the tractor or eq
 
 For this you get back the base costs (deposit) that was paid at the beginning.
 
+Changelog v1.1.0.0:
+- Moddesc update
+- Added translation br,tr and it
+- Fixed bug for additional costs for selling owned vehicles
+
 For more information, help, and reporting issues please visit <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></en>
     <de><![CDATA[Schluss damit die Schlepper und Geräte des Händlers kaputt zu fahren und dafür nicht belangt zu werden.
 Mit dieser Mod müsst ihr die Reperaturkosten bei der Rückgabe des Schleppers oder Gerätes bezahlen. Zusätzlich fallen Reinigungskosten, maximal 30% von den Basiskosten (Kaution), an wenn der Schlepper / das Gerät dreckig abgegeben wird.
 
 Dafür bekommst du die Basiskosten (Kaution) die Anfangs bezahlt wurde, wieder zurück.
+
+Changelog v1.1.0.0:
+- Moddesc aktualisiert
+- Neue Übersetzung für br,tr und it
+- Bug behoben, der für zusätzliche Kosten sorgt beim verkauf von gekauften Fahrzeugen
 
 Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></de>
@@ -29,6 +39,11 @@ Bu mod ile traktörü veya ekipmanı iade ettiğinizde onarım masraflarını ö
 
 Bunun için başlangıçta ödenen temel masrafları (depozito) geri alırsınız.
 
+Değişiklik günlüğü v1.1.0.0:
+- Moddesc güncellemesi
+- br,tr ve it çevirileri eklendi
+- Sahip olunan araçların satışı için ek maliyetler için hata düzeltildi
+
 Daha fazla bilgi, yardım ve sorun bildirme için lütfen <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a> adresini ziyaret edin.
 ]]></tr>
     <br><![CDATA[Pare de quebrar os tratores e equipamentos do revendedor e não ter que pagar por isso.
@@ -36,12 +51,22 @@ Com este mod, você tem que pagar os custos de reparo quando devolver o trator o
 
 Para isso, você recebe de volta os custos base (depósito) que foram pagos no início.
 
+Changelog v1.1.0.0:
+- Atualização do Moddesc
+- Adicionada tradução br,tr e it
+- Corrigido bug para custos adicionais para vender veículos próprios
+
 Para mais informações, ajuda e relatórios de problemas, visite o <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></br>
     <it><![CDATA[Stop con il rompere i trattori e le attrezzature del rivenditore senza dover pagare per i danni.
 Con questa mod devi pagare i costi di riparazione quando restituisci il trattore o l'attrezzatura. Inoltre, devi pagare i costi di lavaggio, massimo il 30% dei costi base (deposito), per un trattore o un'attrezzatura sporchi.
 
 Per questo ti viene restituito il deposito che è stato pagato all'inizio.
+
+Changelog v1.1.0.0:
+- Aggiornamento Moddesc
+- Aggiunta traduzione br, tr e it
+- Corretto bug per costi aggiuntivi per la vendita di veicoli di proprietà
 
 Per maggiori informazioni, assistenza e segnalazione di problemi, visita <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></it>

--- a/FS25_ExtendedLeasing/modDesc.xml
+++ b/FS25_ExtendedLeasing/modDesc.xml
@@ -5,7 +5,8 @@
   <title>
     <en>Extended Leasing</en>
     <de>Erweitertes Leasing</de>
-	<tr>Genişletilmiş Kiralama</tr>
+	  <tr>Genişletilmiş Kiralama</tr>
+    <br>Locação estendido</br>
   </title>
   <description>
     <en><![CDATA[Stop with breaking down the dealer's tractors and equipment and not having to pay for it.
@@ -22,6 +23,20 @@ Dafür bekommst du die Basiskosten (Kaution) die Anfangs bezahlt wurde, wieder z
 
 Weitere Informationen, Hilfe und Probleme melden findest Du unter <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
 ]]></de>
+    <tr><![CDATA[Bayinin traktörlerini ve ekipmanlarını parçalayıp bunun için ödeme yapmaktan vazgeçin.
+Bu mod ile traktörü veya ekipmanı iade ettiğinizde onarım masraflarını ödemeniz gerekir. Ayrıca kirli bir traktör veya ekipman için yıkama masraflarını, temel masrafların (depozito) en fazla %30'unu ödemeniz gerekir.
+
+Bunun için başlangıçta ödenen temel masrafları (depozito) geri alırsınız.
+
+Daha fazla bilgi, yardım ve sorun bildirme için lütfen <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a> adresini ziyaret edin.
+]]></tr>
+    <br><![CDATA[Pare de quebrar os tratores e equipamentos do revendedor e não ter que pagar por isso.
+Com este mod, você tem que pagar os custos de reparo quando devolver o trator ou equipamento. Além disso, você tem que pagar os custos de lavagem, no máximo 30% dos custos base (depósito), para um trator ou equipamento sujo.
+
+Para isso, você recebe de volta os custos base (depósito) que foram pagos no início.
+
+Para mais informações, ajuda e relatórios de problemas, visite o <a href='https://github.com/Peppie84/FS25_ExtendedLeasing'>GitHub</a>.
+]]></br>
   </description>
   <iconFilename>icon_ExtendedLeasing.dds</iconFilename>
   <multiplayer supported="true" />

--- a/FS25_ExtendedLeasing/src/events/SellVehicleEventExtended.lua
+++ b/FS25_ExtendedLeasing/src/events/SellVehicleEventExtended.lua
@@ -19,7 +19,7 @@ function SellVehicleEventExtended:run(overwrittenFunc, connection)
             local farmId = self.vehicle:getOwnerFarmId()
             local farm = g_farmManager:getFarmById(farmId)
 
-            if self.vehicle.propertyState ~= Vehicle.PROPERTY_STATE_OWNED then
+            if self.vehicle.propertyState ~= VehiclePropertyState.OWNED then
                 if farmId ~= nil and farmId ~= FarmManager.SPECTATOR_FARM_ID and farm ~= nil then
                     local vehiclePrice = self.vehicle:getPrice()
                     local depositReturn = MathUtil.round(vehiclePrice * EconomyManager.DEFAULT_LEASING_DEPOSIT_FACTOR, 0)

--- a/FS25_ExtendedLeasing/translations/l10n_br.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_br.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Myiamoto86</translationContributors>
+  <elements>
+    <e k="base_costs" v="Retorno de custos básicos"/>
+    <e k="washing_costs" v="Custos de lavagem"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_de.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_de.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Peppie84</translationContributors>
+  <elements>
+    <e k="base_costs" v="Kaution zurück"/>
+    <e k="washing_costs" v="Reinigungsgebühr"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_en.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_en.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Peppie84</translationContributors>
+  <elements>
+    <e k="base_costs" v="Base Costs Return"/>
+    <e k="washing_costs" v="Washing Costs"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_it.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_it.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>FirenzeIT</translationContributors>
+  <elements>
+    <e k="base_costs" v="Costo base di ritorno"/>
+    <e k="washing_costs" v="Costo lavaggio"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_ru.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_ru.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Gonimy_Vetrom</translationContributors>
+  <elements>
+    <e k="base_costs" v="Возврат базовых расходов"/>
+    <e k="washing_costs" v="Расходы на мойку"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_tr.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_tr.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>RuyaSavascisi</translationContributors>
+  <elements>
+    <e k="base_costs" v="Temel Masrafların İadesi"/>
+    <e k="washing_costs" v="Yıkama Masrafı"/>
+  </elements>
+</l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_uk.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_uk.xml
@@ -3,6 +3,6 @@
   <translationContributors>Gonimy_Vetrom</translationContributors>
   <elements>
     <e k="base_costs" v="Повернення базових витрат"/>
-    <e k="washing_costs" v="Витрати на майку"/>
+    <e k="washing_costs" v="Витрати на мийку"/>
   </elements>
 </l10n>

--- a/FS25_ExtendedLeasing/translations/l10n_uk.xml
+++ b/FS25_ExtendedLeasing/translations/l10n_uk.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<l10n>
+  <translationContributors>Gonimy_Vetrom</translationContributors>
+  <elements>
+    <e k="base_costs" v="Повернення базових витрат"/>
+    <e k="washing_costs" v="Витрати на майку"/>
+  </elements>
+</l10n>

--- a/prepare-release.ps1
+++ b/prepare-release.ps1
@@ -48,7 +48,7 @@ $xmlStreamWriter.Close()
 
 # Make test run (add testrunner path to your environment path)
 New-Item -ItemType Directory -Force -Path "$testRunnerLogPath"
-TestRunner_public --logPath "$testRunnerLogPath" --outputPath "$testRunnerLogPath" --noPause "$modDirectory\"
+LS25TestRunner_public --logPath "$testRunnerLogPath" --outputPath "$testRunnerLogPath" --noPause "$modDirectory\"
 
 # Make zip file
 7z a -bd -stl -tzip -mx=9 "$modName.zip" "$modDirectory/."


### PR DESCRIPTION
**[v1.1.0.0] - 2025-01-28**
- Update moddesc version
- Pull out the translation in single files for [#4](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/4)
- Added `l10n_tr.xml` by [RuyaSavascisi](https://github.com/RuyaSavascisi)
- Added `l10n_br.xml` by [Myiamoto86](https://github.com/Myiamoto86)
- Added `l10n_it.xml` by [FirenzeIT](https://github.com/FirenzeIT)
- Fixed additional costs for selling owned vehicles for [#10](https://github.com/Peppie84/FS25_ExtendedLeasing/issues/10)